### PR TITLE
Decompose 9x9 kernel into tower-like layers without latent variables

### DIFF
--- a/arch/nvae/decoder.py
+++ b/arch/nvae/decoder.py
@@ -1,3 +1,4 @@
+import math
 import torch
 import torch.nn as nn
 import torchvision.ops as ops
@@ -158,21 +159,27 @@ class Decoder(nn.Module):
                 
                 num_channels //= 2
     
-        # Build postprocessing layers
+        # Build postprocessing modules
         
-        self.postprocess = nn.Sequential(
-            DecoderResidualCell(num_channels),
-            nn.ConvTranspose2d(
-                num_channels,
-                num_channels,
-                kernel_size=final_upsample_factor + 1,
-                stride=final_upsample_factor,
-                padding=1,
-                output_padding=1,
-                bias=False,
-            ),
-            DecoderResidualCell(num_channels),
-        )
+        postprocess_modules = []
+        num_postprocess_layers = int(math.log2(final_upsample_factor))
+        
+        for _ in range(num_postprocess_layers):
+            postprocess_modules.append(
+                nn.ConvTranspose2d(
+                    num_channels,
+                    num_channels,
+                    kernel_size=3,
+                    stride=2,
+                    padding=1,
+                    output_padding=1,
+                    bias=False,
+                )
+            )
+            postprocess_modules.append(DecoderResidualCell(num_channels))
+            postprocess_modules.append(DecoderResidualCell(num_channels))
+        
+        self.postprocess = nn.Sequential(*postprocess_modules)
 
     def forward(
         self,

--- a/arch/nvae/encoder.py
+++ b/arch/nvae/encoder.py
@@ -1,9 +1,7 @@
+import math
 import torch
 import torch.nn as nn
 import torchvision.ops as ops
-
-from arch.nvae.distribution import Normal
-from utils.utils import soft_clamp
 
 class EncoderResidualCell(nn.Module):
     """
@@ -77,24 +75,30 @@ class Encoder(nn.Module):
         
         assert len(num_groups_per_layer) == num_latent_layers
         
-        # Build preprocessing layers
+        # Build preprocessing modules
         
         # In official NVAE implementation, by default arch_type is 'res_mbconv'
         # and so 'down_pre' is ['res_bnswish', 'res_bnswish'] with 2 preprocess
         # cells, 1 preprocess block and channel multiplier of 1.
         
-        self.preprocess = nn.Sequential(
-            EncoderResidualCell(initial_channels),
-            nn.Conv2d(
-                initial_channels,
-                initial_channels,
-                kernel_size=initial_downsample_factor + 1,
-                stride=initial_downsample_factor,
-                padding=initial_downsample_factor // 2,
-                bias=False,
-            ),
-            EncoderResidualCell(initial_channels),
-        )
+        preprocess_modules = []
+        num_preprocess_layers = int(math.log2(initial_downsample_factor))
+        
+        for _ in range(num_preprocess_layers):
+            preprocess_modules.append(EncoderResidualCell(initial_channels))
+            preprocess_modules.append(EncoderResidualCell(initial_channels))
+            preprocess_modules.append(
+                nn.Conv2d(
+                    initial_channels,
+                    initial_channels,
+                    kernel_size=3,
+                    stride=2,
+                    padding=1,
+                    bias=False,
+                )
+            )
+        
+        self.preprocess = nn.Sequential(*preprocess_modules)
         
         # Build tower
         


### PR DESCRIPTION
This is done in the preprocessing and postprocessing blocks of the NVAE encoder and decoder respectively.

The number of channels are kept at 16 throughout.

It would be interesting to double it, e.g. 16 -> 32 -> 64, or start off lower: 8 -> 16 -> 32, then the tower starts at 32 channels. This would, however, increase memory requirements.